### PR TITLE
Accept also max, min to be a number (the size of the string/buffer in bytes)

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ module.exports = function (max, min, useGzip) {
 		throw new Error('`max` and `min` required');
 	}
 
-	var ret = format(max.length) + arrow + format(min.length);
+	var ret = format(typeof max === 'number' ? max : max.length) + arrow + format(typeof min === 'number' ? min : min.length);
 
-	if (useGzip === true) {
+	if (useGzip === true && typeof min !== 'number') {
 		ret += arrow + format(gzipSize.sync(min)) + chalk.gray(' (gzip)');
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -34,23 +34,23 @@ console.log(maxmin(max, min, true));
 #### max
 
 *Required*  
-Type: `string`, `buffer`  
+Type: `string`, `buffer`, `number` 
 
-Original string.
+Original string or its size in bytes.
 
 #### min
 
 *Required*  
-Type: `string`, `buffer`  
+Type: `string`, `buffer`, `number` 
 
-Minified string.
+Minified string or its size in bytes.
 
 #### useGzip
 
 Type: `boolean`  
 Default: `false`
 
-Show gzipped size of `min`. Pretty slow.
+Show gzipped size of `min`. Pretty slow. Now shown when `min` is a `number`.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -6,7 +6,17 @@ var maxmin = require('./');
 var max = 'function smoothRangeRandom(min,max){var num=Math.floor(Math.random()*(max-min+1)+min);return this.prev=num===this.prev?++num:num};function smoothRangeRandom(min,max){var num=Math.floor(Math.random()*(max-min+1)+min);return this.prev=num===this.prev?++num:num};function smoothRangeRandom(min,max){var num=Math.floor(Math.random()*(max-min+1)+min);return this.prev=num===this.prev?++num:num};';
 var min = 'function smoothRangeRandom(b,c){var a=Math.floor(Math.random()*(c-b+1)+b);return this.prev=a===this.prev?++a:a}function smoothRangeRandom(b,c){var a=Math.floor(Math.random()*(c-b+1)+b);return this.prev=a===this.prev?++a:a}function smoothRangeRandom(b,c){var a=Math.floor(Math.random()*(c-b+1)+b);return this.prev=a===this.prev?++a:a};';
 
-test('should generate correct output', function (t) {
+test('should generate correct output for strings', function (t) {
 	t.assert(chalk.stripColor(maxmin(max, min)) === '390 B → 334 B');
 	t.assert(chalk.stripColor(maxmin(max, min, true)) === '390 B → 334 B → 120 B (gzip)');
+});
+
+test('should generate correct output for buffers', function (t) {
+	t.assert(chalk.stripColor(maxmin(new Buffer(max), new Buffer(min))) === '390 B → 334 B');
+	t.assert(chalk.stripColor(maxmin(new Buffer(max), new Buffer(min), true)) === '390 B → 334 B → 120 B (gzip)');
+});
+
+test('should generate correct output for integers', function (t) {
+	t.assert(chalk.stripColor(maxmin(max.length, min.length)) === '390 B → 334 B');
+	t.assert(chalk.stripColor(maxmin(max.length, min.length, true)) === '390 B → 334 B');
 });


### PR DESCRIPTION
To create a summary report for some grunt-contrib modules it would be good to allow max & min be only the size of the string or buffer. Otherwise we would need to keep all the strings / buffers in memory which requires a lot of memory.
See https://github.com/gruntjs/grunt-contrib-cssmin/pull/200

Beside a test for it I also added a test for max, min being buffers.